### PR TITLE
travis: add ruby-2.4, remove broken jruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
  - 2.1
  - 2.2
  - 2.3
+ - 2.4
  - ruby-head
- - jruby


### PR DESCRIPTION
Don't know why jruby doesn't work now, it took forever fixing it in the first place.