### PR TITLE
Bump version + update gemspec

### DIFF
--- a/konfa.gemspec
+++ b/konfa.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.name        = 'konfa'
-  s.version     = '0.4.3'
-  s.date        = '2017-06-15'
+  s.version     = '0.4.4'
+  s.date        = '2018-06-07'
   s.summary     = "Application configuration"
   s.description = "Helps you avoid common pitfalls when dealing with app config"
-  s.authors     = ["Gunnar Hansson", "Avidity"]
-  s.email       = 'code@avidiy.se'
+  s.authors     = ["Gunnar Hansson", "Promote International"]
+  s.email       = 'code@promoteint.com'
   s.files       = Dir.glob("lib/**/*.rb")
-  s.homepage    = 'http://github.com/avidity/konfa'
+  s.homepage    = 'http://github.com/promoteinternational/konfa'
   s.license     = 'MIT'
 
   s.add_dependency "method_source", "~> 0.8"


### PR DESCRIPTION
This bumps the version number after merging new interface for merging configurations (see #15 ) 

Also, update gemspec with Promote International's details.