### PR TITLE
Drop old Bundler dependency and version constraint

### DIFF
--- a/konfa.gemspec
+++ b/konfa.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency "method_source", "~> 0.8"
-  s.add_development_dependency "bundler", "~> 1.13"
   s.add_development_dependency "rake", "~> 12.0"
   s.add_development_dependency "rspec", "~> 3.6"
   s.add_development_dependency "ruby_dep", "~> 1.3.1"


### PR DESCRIPTION
Builds were failing on ruby head due to this old version constraint. Since now there's no reason to lock it or declare it as a development dependency, also remove the dependency declaration.