### PR TITLE
Improve new initialization interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,40 @@ MyAppConfig.init_with(:numbers) # Don't include prefix in symbol
 
 MyAppConfig.get(:my_var) # => 01234
 ```
+
+## Version 0.5.x
+
+Konfa 0.5 introduces new methods for initializing configurations, meant to provide
+a simpler interface and a cleaner way of using multiple YAML files and/or multiple
+initializers. Catching errors early is strongly encouraged, therefore,
+`initialize!` must be called explicitly when finished loading configurations.
+
+```ruby
+require 'konfa'
+
+class MyAppConfig < Konfa::Base
+  def self.allowed_variables
+    {
+      lasers: 'off',
+      tasers: 'on',
+    }
+  end
+
+  def self.env_variable_prefix
+    'MY_APP_'
+  end
+end
+
+MyAppConfig.read_from(:yaml, 'config/values.yaml', 'config/local_overrides.yaml' )
+MyAppConfig.read_from(:env)
+MyAppConfig.initialize! # after_initialize is invoked once
+
+if MyAppConfig.true?(:lasers)
+  # do stuff
+end
+```
+
+**NOTE¹:** when using `read_from`, accessing variables without initializing
+first will raise an exception in Konfa 1.0.  
+**NOTE²:** the old initialization interface is now deprecated and will be
+removed in Konfa 1.0.

--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -134,9 +134,11 @@ module Konfa
         self.initialized = false
       end
 
-      def read_from(initializer, *files)
+      def read_from(initializer, *args)
+        raise AlreadyInitializedError if self.initialized?
         raise UnsupportedInitializerError unless self.respond_to?(:"init_with_#{initializer}")
-        files.each { |file| self.send(:"init_with_#{initializer}", file) }
+
+        self.send(:"init_with_#{initializer}", *args)
         self
       end
 

--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -140,18 +140,12 @@ module Konfa
         self
       end
 
-      def initialized!
-        unless self.initialized?
-          @initialized = true
-          self.after_initialize
-        end
+      def initialize!
+        raise AlreadyInitializedError if self.initialized?
 
+        @initialized = true
+        self.after_initialize
         self
-      end
-
-      def initialize!(initializer, *files)
-        self.read_from(initializer, *files)
-        self.initialized!
       end
 
       def initialized?
@@ -178,6 +172,7 @@ module Konfa
   end
 
   class UnsupportedInitializerError < StandardError; end
+  class AlreadyInitializedError < StandardError; end
   class UnsupportedVariableError < StandardError; end
   class NilVariableError < StandardError; end
 end

--- a/lib/konfa/initializer.rb
+++ b/lib/konfa/initializer.rb
@@ -7,17 +7,19 @@ module Konfa
     end
 
     module ClassMethods
-      def init_with_yaml(path)
-        # FIXME: It would be a lot cleaner if the YAML library would raise an
-        # exception if it fails to read the file. We'll handle it like this for now
-        # load_file just returns "false" if it fails
-        yaml_data = YAML.load_file(path)
+      def init_with_yaml(*paths)
+        paths.each do |path|
+          # FIXME: It would be a lot cleaner if the YAML library would raise an
+          # exception if it fails to read the file. We'll handle it like this for now
+          # load_file just returns "false" if it fails
+          yaml_data = YAML.load_file(path)
 
-        unless yaml_data.nil?
-          raise Konfa::InitializationError.new("Bad YAML format, key/value pairs expected") unless yaml_data.kind_of?(Hash)
+          unless yaml_data.nil?
+            raise Konfa::InitializationError.new("Bad YAML format, key/value pairs expected") unless yaml_data.kind_of?(Hash)
 
-          yaml_data.each do |variable, value|
-            self.store(variable, value)
+            yaml_data.each do |variable, value|
+              self.store(variable, value)
+            end
           end
         end
 

--- a/spec/konfa/initializer_spec.rb
+++ b/spec/konfa/initializer_spec.rb
@@ -18,8 +18,15 @@ describe Konfa::Initializer do
   end
 
   context "#init_with_yaml" do
+    it 'dumps configuration' do
+      expect(subject).to receive(:dump)
+
+      subject.init_with_yaml(good_file)
+    end
+
     it 'calls store with data from yaml' do
       expect(subject).to receive(:store).with('my_var', 'read from the yaml file')
+
       subject.init_with_yaml(good_file)
     end
 
@@ -29,7 +36,7 @@ describe Konfa::Initializer do
       }.to raise_error(Konfa::InitializationError)
     end
 
-    it "raises an exception if file does not key/value pairs" do
+    it "raises an exception if file does not contain key/value pairs" do
       expect {
         subject.init_with_yaml(array_file)
       }.to raise_error(Konfa::InitializationError)
@@ -40,6 +47,18 @@ describe Konfa::Initializer do
       expect {
         subject.init_with_yaml(empty_file)
       }.not_to raise_error
+    end
+
+    it 'stores data from multiple files' do
+      initial_file = File.expand_path("../../support/initial_config.yaml", __FILE__)
+      overrides_file = File.expand_path("../../support/overrides.yaml", __FILE__)
+
+      expect(subject).to receive(:store).with('foo', 'foo')
+      expect(subject).to receive(:store).with('bar', 'bar')
+      expect(subject).to receive(:store).with('baz', 'baz')
+      expect(subject).to receive(:store).with('foo', 'overrides initial config foo var')
+
+      subject.init_with_yaml(initial_file, overrides_file)
     end
   end
 

--- a/spec/konfa_spec.rb
+++ b/spec/konfa_spec.rb
@@ -34,8 +34,8 @@ class MyOtherTestKonfa < Konfa::Base
 end
 
 describe Konfa do
-  let(:bool_file)  { File.expand_path('../support/bool_config.yaml', __FILE__) }
-  let(:good_file)  { File.expand_path('../support/good_config.yaml', __FILE__) }
+  let(:bool_file) { File.expand_path('../support/bool_config.yaml', __FILE__) }
+  let(:good_file) { File.expand_path('../support/good_config.yaml', __FILE__) }
   let(:initial_file) { File.expand_path('../support/initial_config.yaml', __FILE__) }
   let(:overrides_file) { File.expand_path('../support/overrides.yaml', __FILE__) }
 
@@ -437,63 +437,43 @@ describe Konfa do
     end
   end
 
-  describe '.initialized!' do
-    subject { MyTestKonfa.initialized! }
+  describe '.initialize!' do
+    it 'sets initialized state' do
+      MyTestKonfa.read_from(:yaml, good_file)
 
-    it 'sets initialized to true' do
       expect {
-        subject
+        MyTestKonfa.initialize!
       }.to change { MyTestKonfa.initialized? }.from(false).to(true)
     end
 
     it 'calls after_initialize' do
+      MyTestKonfa.read_from(:yaml, good_file)
+
       expect(MyTestKonfa).to receive(:after_initialize)
-      subject
+
+      MyTestKonfa.initialize!
     end
 
-    it 'returns self' do
-      expect(subject).to eq MyTestKonfa
-    end
+    it 'raises error when already initialized' do
+      MyTestKonfa.read_from(:yaml, initial_file).initialize!
 
-    context 'when already initialized' do
-      before(:each) { allow(MyTestKonfa).to receive(:initialized?).and_return(true) }
-
-      it 'does not run' do
-        expect(MyTestKonfa).not_to receive(:after_initialize)
-        expect(subject).to eq MyTestKonfa
-      end
+      expect {
+        MyTestKonfa.initialize!
+      }.to raise_error(Konfa::AlreadyInitializedError)
     end
   end
 
   describe '.initialized?' do
-    subject { MyTestKonfa }
+    it 'is true when initialized' do
+      MyTestKonfa.read_from(:yaml, good_file).initialize!
 
-    context 'when not initialized' do
-      it { is_expected.not_to be_initialized }
+      expect(MyTestKonfa).to be_initialized
     end
 
-    context 'when already initialized' do
-      before(:each) { MyTestKonfa.initialized! }
+    it 'is false when not initialized' do
+      MyTestKonfa.read_from(:yaml, good_file)
 
-      it { is_expected.to be_initialized }
-    end
-  end
-
-  describe '.initialize!' do
-    subject { MyTestKonfa.initialize!(:yaml, good_file) }
-
-    it 'loads the config and initializes' do
-      expect(MyTestKonfa).to receive(:read_from).with(:yaml, good_file)
-      expect(MyTestKonfa).to receive(:initialized!)
-
-      MyTestKonfa.initialize!(:yaml, good_file)
-    end
-
-    it 'accepts multiple files' do
-      expect(MyTestKonfa).to receive(:read_from).with(:yaml, initial_file, overrides_file).once
-      expect(MyTestKonfa).to receive(:initialized!).once
-
-      MyTestKonfa.initialize!(:yaml, initial_file, overrides_file)
+      expect(MyTestKonfa).not_to be_initialized
     end
   end
 end


### PR DESCRIPTION
Simplify and clean up new interface and take the first steps to enforce early initialization in order to make the transition into version 1.0 smoother and the library more coherent overall.

Overview of the changes
* Remove unnecessary shortcut method
* Give the initialization method a more adequate name by using the imperative form
* Enforce new explicit *load > initialize > read* workflow by only allowing to initialize once and not allowing to read configs after initialized
* Move multiple yaml files logic where it belongs
* Add notes about new interface to the README

There's one known caveat: for now it's technically possible to `read_from` and access a variable without initializing first because that makes it easier to preserve backwards compatibility on the variable access methods. This is not mentioned in the README on purpose since doing that is strongly discouraged as it will not be allowed in 1.0; so basically, I think we can just not support it but not go out of our way to prevent it.