### PR TITLE
Prevent new-style deprecation warnings

### DIFF
--- a/lib/konfa.rb
+++ b/lib/konfa.rb
@@ -36,7 +36,8 @@ module Konfa
       end
 
       def configuration
-        self.init
+        self.init if self.initializer
+
         @configuration ||= default_values
       end
 


### PR DESCRIPTION
This PR prevents the lazy initialize call unless an old-style initializer has been set